### PR TITLE
Safari fix for the ImageWithPlacehold/Avatar transition oddness

### DIFF
--- a/components/Avatar/Avatar.module.scss
+++ b/components/Avatar/Avatar.module.scss
@@ -1,5 +1,6 @@
 .avatar {
   align-items: center;
+  background-color: #fff;
   border-radius: 50%;
   display: inline-flex;
   justify-content: center;

--- a/components/Avatar/Avatar.module.scss
+++ b/components/Avatar/Avatar.module.scss
@@ -6,6 +6,12 @@
   overflow: hidden;
   position: relative;
 
+  // Adding here, otherwise in Safari the `ImageWithPlaceholder.img.transition`
+  // transition a square image for 0.5 seconds into a circle.
+  img {
+    border-radius: 50%;
+  }
+
   &Border {
     border: solid var(--background) 3px;
   }


### PR DESCRIPTION
Before this commit, in Safari, the experience would be:

- ImageWithPlaceholder would render a grey placeholder as a square.
- Then transition to the image for 0.5 seconds.
- Then turn into the circle Avatar we know and love.

This seems to keep the behaviour folks want, but also stops the oddness
in Safari.


Also resolves #70