### PR TITLE
Use Preact in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  webpack: (config, { dev, isServer }) => {
+    if (!dev && !isServer) {
+      Object.assign(config.resolve.alias, {
+        react: "preact/compat",
+        "react-dom/test-utils": "preact/test-utils",
+        "react-dom": "preact/compat",
+      });
+    }
+
+    return config;
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "gray-matter": "^4.0.3",
         "next": "10.2.2",
         "next-themes": "^0.0.14",
+        "preact": "^10.5.13",
         "prismjs": "^1.23.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -11660,6 +11661,15 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.5.13",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.13.tgz",
+      "integrity": "sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prebuild-install": {
@@ -25440,6 +25450,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
+    },
+    "preact": {
+      "version": "10.5.13",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.13.tgz",
+      "integrity": "sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ=="
     },
     "prebuild-install": {
       "version": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gray-matter": "^4.0.3",
     "next": "10.2.2",
     "next-themes": "^0.0.14",
+    "preact": "^10.5.13",
     "prismjs": "^1.23.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",


### PR DESCRIPTION
[Preact](https://preactjs.com/) is basically React but a smaller package size so makes our site a bit faster to load 🙂 

React version:
![image](https://user-images.githubusercontent.com/16718355/121179810-09ade280-c858-11eb-8861-29175ff7f8e5.png)

Preact version:
![image](https://user-images.githubusercontent.com/16718355/121179833-0e729680-c858-11eb-8411-3b4e1f6bf6b2.png)

I've used this setup on another site and not hit any major problems so far, just a few minor things that I had to fix with external packages that didn't work well so worth keeping an eye on anything we add via `npm run build && npm start` but the PR deployment will do the same thing 🙂 