### PR TITLE
Run the lighthouse report on PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,9 +8,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: amondnet/vercel-action@v20
+        id: "vercel-action"
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.ORG_ID}}
           vercel-project-id: ${{ secrets.PROJECT_ID}}
           working-directory: ./
+      - run: mkdir /tmp/artifacts
+      - name: Run Lighthouse
+        uses: foo-software/lighthouse-check-action@master
+        with:
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          author: ${{ github.actor }}
+          branch: ${{ github.ref }}
+          outputDirectory: /tmp/artifacts
+          urls: ${{ steps.vercel-action.outputs.preview-url }}
+          sha: ${{ github.sha }}
+          slackWebhookUrl: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: Lighthouse reports
+          path: /tmp/artifacts


### PR DESCRIPTION
Resolves #26

For now, we are only running on the home page, but we can add more. I see @markgaze said it can slow stuff down, so we can decide if the homepage is on PRs, and other main sites are on `main`.

I don't think, due to other commitments, our merge times are too slow at the moment.