### PR TITLE
Added a z-index to the Authors name

### DIFF
--- a/components/Subheader/Subheader.tsx
+++ b/components/Subheader/Subheader.tsx
@@ -99,7 +99,7 @@ const Subheader = (props: ISubheaderProps): JSX.Element => {
         </ul>
       </div>
       <div className={styles.author}>
-        <Author author={author} avatarBorder avatarSize="medium" />
+        <Author author={author} avatarBorder avatarSize="medium" vertical />
       </div>
     </div>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,7 +43,6 @@ const Home = (props: IHomeProps): JSX.Element => {
                 avatarBorder
                 avatarSize="medium"
                 textTheme="light"
-                vertical
               />
             </div>
           </div>


### PR DESCRIPTION
Resolves #86

Noticed on a post the authors name clipped below the top bar thing. Simple z-index application should do the trick. Tested the other places I know this component comes up and all looks fine.