### PR TITLE
Improve client-side transitions and stabilize theme toggle

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -7,6 +7,7 @@ import Avatar from "./Avatar.astro";
 const { data, slug } = Astro.props.post;
 const subtitleTrimmed = data.subtitle.split(" ").slice(0, 20).join(" ").trimEnd();
 const authorProfile = getAuthorData(data.author);
+const transitionSlug = slug.replaceAll("/", "-");
 ---
 
 <a href={`/post/${slug}`} class="group cursor-pointer no-underline" title={data.title}>
@@ -15,22 +16,32 @@ const authorProfile = getAuthorData(data.author);
   >
     <div class="relative h-40 overflow-hidden">
       <Image
+        transition:name={`post-image-${transitionSlug}`}
         class="h-full w-full object-cover"
         alt={data.title}
         src={import(`../images/posts/featured/${data.featuredImage.replace(".jpg", "")}.jpg`)}
         height={160}
         width={680}
       />
-      <div class="pointer-events-none absolute inset-0 hidden bg-black/40 transition dark:block">
+      <div
+        transition:name={`post-image-dim-${transitionSlug}`}
+        class="pointer-events-none absolute inset-0 bg-transparent transition dark:bg-black/40"
+      >
       </div>
     </div>
     <div class="flex flex-1 flex-col px-4 pb-5 pt-6">
       <span class="text-xs">
-        <span class="font-header font-bold uppercase">{data.category}</span>
+        <span
+          transition:name={`post-category-${transitionSlug}`}
+          class="font-header font-bold uppercase">{data.category}</span
+        >
         {" - "}
-        <span>{getDateFormatted(data.date.toString())}</span>
+        <span transition:name={`post-date-${transitionSlug}`}
+          >{getDateFormatted(data.date.toString())}</span
+        >
       </span>
       <h2
+        transition:name={`post-title-${transitionSlug}`}
         class="font-header my-2 mb-4 text-[1.375rem] font-bold leading-(--line-height-header) text-link group-hover:underline"
       >
         {data.title}

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -29,19 +29,16 @@ const transitionSlug = slug.replaceAll("/", "-");
       >
       </div>
     </div>
-    <div class="flex flex-1 flex-col px-4 pb-5 pt-6">
+    <div
+      transition:name={`post-surface-${transitionSlug}`}
+      class="flex flex-1 flex-col px-4 pb-5 pt-6"
+    >
       <span class="text-xs">
-        <span
-          transition:name={`post-category-${transitionSlug}`}
-          class="font-header font-bold uppercase">{data.category}</span
-        >
+        <span class="font-header font-bold uppercase">{data.category}</span>
         {" - "}
-        <span transition:name={`post-date-${transitionSlug}`}
-          >{getDateFormatted(data.date.toString())}</span
-        >
+        <span>{getDateFormatted(data.date.toString())}</span>
       </span>
       <h2
-        transition:name={`post-title-${transitionSlug}`}
         class="font-header my-2 mb-4 text-[1.375rem] font-bold leading-(--line-height-header) text-link group-hover:underline"
       >
         {data.title}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -25,19 +25,14 @@ const transitionSlug = post.slug.replaceAll("/", "-");
           <div
             class="border-b border-[#b676dd] pb-2 text-white dark:border-[#500480] lg:border-[#903ec4]"
           >
-            <span
-              class="font-header text-base font-black capitalize"
-              transition:name={`post-category-${transitionSlug}`}
+            <span class="font-header text-base font-black capitalize"
               >{post.data.category}<span class="px-4">&middot;</span></span
             >
-            <span
-              transition:name={`post-date-${transitionSlug}`}
-              class="text-base leading-(--line-height-text)"
+            <span class="text-base leading-(--line-height-text)"
               >{getDateFormatted(post.data.date.toString())}</span
             >
           </div>
           <h1
-            transition:name={`post-title-${transitionSlug}`}
             class="font-header mt-6 text-[2.25rem] leading-(--line-height-header) font-black text-white md:text-[2.75rem] lg:w-4/5"
           >
             <a class="no-underline hover:underline" href={`/post/${post.slug}`}>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,6 +12,7 @@ const sortedPosts = [...allPosts].sort(
 const post = sortedPosts[0];
 
 const author = getAuthorData(post.data.author);
+const transitionSlug = post.slug.replaceAll("/", "-");
 ---
 
 <header>
@@ -24,14 +25,19 @@ const author = getAuthorData(post.data.author);
           <div
             class="border-b border-[#b676dd] pb-2 text-white dark:border-[#500480] lg:border-[#903ec4]"
           >
-            <span class="font-header text-base font-black capitalize"
+            <span
+              class="font-header text-base font-black capitalize"
+              transition:name={`post-category-${transitionSlug}`}
               >{post.data.category}<span class="px-4">&middot;</span></span
             >
-            <span class="text-base leading-(--line-height-text)"
+            <span
+              transition:name={`post-date-${transitionSlug}`}
+              class="text-base leading-(--line-height-text)"
               >{getDateFormatted(post.data.date.toString())}</span
             >
           </div>
           <h1
+            transition:name={`post-title-${transitionSlug}`}
             class="font-header mt-6 text-[2.25rem] leading-(--line-height-header) font-black text-white md:text-[2.75rem] lg:w-4/5"
           >
             <a class="no-underline hover:underline" href={`/post/${post.slug}`}>
@@ -55,6 +61,7 @@ const author = getAuthorData(post.data.author);
         <div class="relative hidden w-full overflow-hidden rounded-md lg:block">
           <a href={`/post/${post.slug}`} aria-label="Featured image" title="Featured image">
             <Image
+              transition:name={`post-image-${transitionSlug}`}
               class="h-full w-full object-cover"
               alt=""
               src={import(
@@ -64,7 +71,8 @@ const author = getAuthorData(post.data.author);
             />
           </a>
           <div
-            class="pointer-events-none absolute inset-0 hidden bg-black/40 transition dark:block"
+            transition:name={`post-image-dim-${transitionSlug}`}
+            class="pointer-events-none absolute inset-0 bg-transparent transition dark:bg-black/40"
           >
           </div>
         </div>

--- a/src/components/ThemeButton.astro
+++ b/src/components/ThemeButton.astro
@@ -41,13 +41,26 @@ import { Icon } from "astro-icon/components";
     applyTheme();
   };
 
-  applyTheme();
-  darkModeQuery.addEventListener("change", (event) => {
-    const nextTheme = event.matches ? "dark" : "light";
-    localStorage.setItem("theme", nextTheme);
+  const setupThemeButton = () => {
     applyTheme();
-  });
+    const button = document.getElementById("theme-button");
+    if (button) {
+      button.onclick = toggleTheme;
+    }
+  };
 
-  const button = document.getElementById("theme-button");
-  button?.addEventListener("click", toggleTheme);
+  if (!document.documentElement.dataset.themeMediaListenerBound) {
+    darkModeQuery.addEventListener("change", (event) => {
+      const nextTheme = event.matches ? "dark" : "light";
+      localStorage.setItem("theme", nextTheme);
+      applyTheme();
+    });
+    document.documentElement.dataset.themeMediaListenerBound = "true";
+  }
+
+  setupThemeButton();
+  if (!document.documentElement.dataset.themePageLoadListenerBound) {
+    document.addEventListener("astro:page-load", setupThemeButton);
+    document.documentElement.dataset.themePageLoadListenerBound = "true";
+  }
 </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Footer from "../components/Footer.astro";
 import Nav from "../components/Nav.astro";
+import { ClientRouter } from "astro:transitions";
 import "../styles/tailwind.css";
 
 export type Props = {
@@ -12,6 +13,7 @@ const { title = "somedevsdo" } = Astro.props as Props;
 
 <html lang="en">
   <head>
+    <ClientRouter />
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -27,12 +29,18 @@ const { title = "somedevsdo" } = Astro.props as Props;
     <meta content="summary_large_image" name="twitter:card" />
     <title>{title}</title>
     <script is:inline>
-      const defaultTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
-        ? "dark"
-        : "light";
-      const theme = localStorage.getItem("theme") || defaultTheme;
-      document.documentElement.setAttribute("data-theme", theme);
-      document.documentElement.style.setProperty("color-scheme", theme);
+      const applyTheme = () => {
+        const defaultTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+        const theme = localStorage.getItem("theme") || defaultTheme;
+        document.documentElement.setAttribute("data-theme", theme);
+        document.documentElement.style.setProperty("color-scheme", theme);
+      };
+
+      applyTheme();
+      document.addEventListener("astro:after-swap", applyTheme);
+      document.addEventListener("astro:page-load", applyTheme);
     </script>
   </head>
   <body>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,9 +36,19 @@ const { title = "somedevsdo" } = Astro.props as Props;
         const theme = localStorage.getItem("theme") || defaultTheme;
         document.documentElement.setAttribute("data-theme", theme);
         document.documentElement.style.setProperty("color-scheme", theme);
+        return theme;
+      };
+
+      const applyThemeToDocument = (doc, theme) => {
+        doc.documentElement.setAttribute("data-theme", theme);
+        doc.documentElement.style.setProperty("color-scheme", theme);
       };
 
       applyTheme();
+      document.addEventListener("astro:before-swap", (event) => {
+        const theme = applyTheme();
+        applyThemeToDocument(event.newDocument, theme);
+      });
       document.addEventListener("astro:after-swap", applyTheme);
       document.addEventListener("astro:page-load", applyTheme);
     </script>

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -56,7 +56,10 @@ const transitionSlug = entry.slug.replaceAll("/", "-");
         </div>
       </div>
     </header>
-    <main class="mx-auto my-6 mb-24 rounded-2.5 bg-content-background p-6 md:px-10 md:py-8">
+    <main
+      transition:name={`post-surface-${transitionSlug}`}
+      class="mx-auto my-6 mb-24 rounded-2.5 bg-content-background p-6 md:px-10 md:py-8"
+    >
       <div class="md:flex md:items-center md:justify-between">
         <ul
           class="mb-4 flex list-none justify-center gap-4 border-b border-primary-background p-0 pb-2 md:order-2 md:mb-0 md:border-0 md:pb-0"
@@ -85,21 +88,16 @@ const transitionSlug = entry.slug.replaceAll("/", "-");
         </ul>
 
         <div class="mb-8 md:order-1 md:mb-0">
-          <span
-            transition:name={`post-category-${transitionSlug}`}
-            class="font-header text-base font-bold capitalize"
+          <span class="font-header text-base font-bold capitalize"
             >{entry.data.category}<span class="px-3">&middot;</span></span
           >
-          <span
-            transition:name={`post-date-${transitionSlug}`}
-            class="text-base leading-(--line-height-text)"
+          <span class="text-base leading-(--line-height-text)"
             >{getDateFormatted(entry.data.date.toString())}</span
           >
         </div>
       </div>
 
       <h1
-        transition:name={`post-title-${transitionSlug}`}
         class="font-header mt-6 mb-4 text-[2.25rem] leading-(--line-height-header) font-bold text-header md:mb-6 md:mt-8 md:text-[2.75rem]"
       >
         {entry.data.title}

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -20,6 +20,7 @@ const { entry } = Astro.props;
 const { Content } = await entry.render();
 
 const author = getAuthorData(entry.data.author);
+const transitionSlug = entry.slug.replaceAll("/", "-");
 ---
 
 <Layout title={entry.data.title}>
@@ -39,6 +40,7 @@ const author = getAuthorData(entry.data.author);
         class="relative mx-auto h-60 overflow-hidden rounded-2.5 bg-primary-background md:h-95 lg:h-110"
       >
         <Image
+          transition:name={`post-image-${transitionSlug}`}
           class="h-full w-full object-cover"
           alt="Featured image"
           src={import(
@@ -48,6 +50,7 @@ const author = getAuthorData(entry.data.author);
           width={860}
         />
         <div
+          transition:name={`post-image-dim-${transitionSlug}`}
           class="pointer-events-none absolute inset-0 bg-transparent transition dark:bg-black/40"
         >
         </div>
@@ -82,16 +85,21 @@ const author = getAuthorData(entry.data.author);
         </ul>
 
         <div class="mb-8 md:order-1 md:mb-0">
-          <span class="font-header text-base font-bold capitalize"
+          <span
+            transition:name={`post-category-${transitionSlug}`}
+            class="font-header text-base font-bold capitalize"
             >{entry.data.category}<span class="px-3">&middot;</span></span
           >
-          <span class="text-base leading-(--line-height-text)"
+          <span
+            transition:name={`post-date-${transitionSlug}`}
+            class="text-base leading-(--line-height-text)"
             >{getDateFormatted(entry.data.date.toString())}</span
           >
         </div>
       </div>
 
       <h1
+        transition:name={`post-title-${transitionSlug}`}
         class="font-header mt-6 mb-4 text-[2.25rem] leading-(--line-height-header) font-bold text-header md:mb-6 md:mt-8 md:text-[2.75rem]"
       >
         {entry.data.title}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -29,6 +29,15 @@
     transition: background 0.2s ease-out;
   }
 
+  html {
+    background-color: var(--primary-background);
+  }
+
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    background-color: var(--primary-background);
+  }
+
   a {
     color: inherit;
   }

--- a/tests/e2e/theme.spec.ts
+++ b/tests/e2e/theme.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+test("theme toggle works after client navigation", async ({ page }) => {
+  await page.goto("/");
+
+  const getTheme = () => page.locator("html").getAttribute("data-theme");
+
+  const initialTheme = await getTheme();
+  await page.locator("#theme-button").click();
+  await expect.poll(async () => await getTheme()).not.toBe(initialTheme);
+
+  const afterFirstToggle = await getTheme();
+  await page.locator('a[href*="post/"]').first().click();
+  await expect(page).toHaveURL(/\/post\//);
+
+  await page.locator("#theme-button").click();
+  await expect.poll(async () => await getTheme()).not.toBe(afterFirstToggle);
+});


### PR DESCRIPTION
## Summary
- Enable Astro `ClientRouter` transitions across the site and add shared transition names for post cards and post pages so hero imagery/surface transitions animate smoothly.
- Fix theme persistence during client-side navigation by reapplying theme state on transition lifecycle events and preventing duplicate theme event listener bindings.
- Add a Playwright regression test that verifies theme toggling still works after navigating to a post via client routing.

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm test`